### PR TITLE
Switched builder image tag to support both linux/amd64 and linux/arm64.

### DIFF
--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -5,9 +5,9 @@
 #desired version of Keycloak
 ARG BASE_IMAGE_TAG=21.1.2
 
-FROM openjdk:15-jdk-alpine AS extensionbuilder
+FROM openjdk:15-jdk-slim AS extensionbuilder
 
-RUN apk add --no-cache bash
+RUN apt-get install -y bash
 
 RUN mkdir -p /app
 


### PR DESCRIPTION
This enables the multi stage build to be executed for both x86 (linux/amd64) and ARM64 (linux/arm64) based platforms.

To validate, run:  

`docker build --platform linux/amd64 -f Dockerfile.multi-stage -t iris .`
`docker build --platform linux/arm64 -f Dockerfile.multi-stage -t iris .`