### PR TITLE
Updated mutli-stage docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 # SPDX-License-Identifier: CC0-1.0
 
 providers
-themes
+# themes

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,13 @@ WORKDIR /opt/keycloak
 # Configure HTTP relative path
 # Use postgres as database
 
-RUN /opt/keycloak/bin/kc.sh build --db=postgres --http-relative-path=/auth --metrics-enabled=true --health-enabled=true --legacy-observability-interface=true --features-disabled=persistent-user-sessions
+RUN /opt/keycloak/bin/kc.sh build \
+    --db=postgres \
+    --http-relative-path=/auth \
+    --metrics-enabled=true \
+    --health-enabled=true \
+    --legacy-observability-interface=true \
+    --features-disabled=persistent-user-sessions
 
 FROM quay.io/keycloak/keycloak:$BASE_IMAGE_TAG
 COPY --from=builder /opt/keycloak/ /opt/keycloak/

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -1,47 +1,46 @@
-# SPDX-FileCopyrightText: 2023 Deutsche Telekom AG
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#desired version of Keycloak
-ARG BASE_IMAGE_TAG=21.1.2
+# Keycloak version set in gitlab-ci
+ARG BASE_IMAGE_TAG
 
-FROM openjdk:15-jdk-slim AS extensionbuilder
 
-RUN apt-get install -y bash
+FROM openjdk:17-jdk-slim AS extensionbuilder
 
-RUN mkdir -p /app
+# Need to declare it again here, so we can pass it to build.sh
+ARG BASE_IMAGE_TAG
+
+RUN apt-get install -y bash && \
+mkdir -p /app/providers
 
 ADD extensions /app/extensions/
-
-RUN mkdir -p /app/providers
-
 WORKDIR /app/extensions
 
-RUN ./build.sh
+RUN ./build.sh $BASE_IMAGE_TAG
 
 FROM quay.io/keycloak/keycloak:$BASE_IMAGE_TAG AS builder
 
 LABEL description="Keycloak Docker image bundled with extensions"
-
-# Enable health and metrics support
-ENV KC_HEALTH_ENABLED=true
-ENV KC_METRICS_ENABLED=true
-ENV KC_CACHE_STACK=kubernetes
-
-# Configure a database vendor
-ENV KC_DB=postgres
-ENV KC_HTTP_RELATIVE_PATH=/auth
 
 COPY --from=extensionbuilder /app/providers/ /opt/keycloak/providers/
 
 ADD themes /opt/keycloak/providers/
 
 WORKDIR /opt/keycloak
-RUN /opt/keycloak/bin/kc.sh build --cache=ispn
+
+RUN /opt/keycloak/bin/kc.sh build \
+    --db=postgres \
+    --http-relative-path=/auth \
+    --metrics-enabled=true \
+    --health-enabled=true \
+    --legacy-observability-interface=true \
+    --features-disabled=persistent-user-sessions
 
 FROM quay.io/keycloak/keycloak:$BASE_IMAGE_TAG
+
+
 COPY --from=builder /opt/keycloak/ /opt/keycloak/
 
-USER root
-
 USER 1000
+

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ This job will build the _IKI_ using Docker commands. It uses the artifacts creat
 
 To build IKI, simply follow the steps outlined in the GitLab example.
 
-1. **Build Extensions**: Execute the `build.sh` script located in the `extensions` directory. This will generate
+1. **Build Extensions**: Execute the `build.sh` script located in the `extensions` directory while passing the version to it. (For example: `build.sh "26.0.8"`). This will generate
    a new directory named `providers`.
 2. **Build Themes**: If you have custom themes, run the `build.sh` script within the `themes` directory. This will
    generate a new directory named `themes`.
@@ -131,10 +131,10 @@ To build IKI, simply follow the steps outlined in the GitLab example.
 ### Multi-stage Docker build
 
 Alternatively, you can use the multi-stage Docker build to build the image. This will build the extensions and themes in
-the first stage and then copy them into the final image.
+the first stage and then copy them into the final image. Don't forget to change/add the correct KEYCLOAK_VERSION in build arg.
 
 ```bash
-  docker build --platform linux/amd64 -t iris -f Dockerfile.multi-stage .
+  docker build --platform linux/amd64 --build-arg=BASE_IMAGE_TAG=${KEYCLOAK_VERSION} -t iris -f Dockerfile.multi-stage .
 ```
 
 ## Code of Conduct

--- a/extensions/build.sh
+++ b/extensions/build.sh
@@ -7,7 +7,7 @@
 LIBS_DIR="./../providers"
 KEYCLOAK_VERSION="$1"
 if [ -z "$KEYCLOAK_VERSION"  ]; then
-        echo "Keycloak version not specified"
+    echo "Keycloak version not specified"
 	exit 1
 fi
 


### PR DESCRIPTION
Hi!

While upgrading to the new version of Iris chart & image I realised that the multi-stage build wasn't updated. This PR makes the changes that was done to the default dockerfile.
I also added a small update in the readme, as the new `KEYCLOAK_VERSION` arg was not mentioned there.

BTW, I tested this new image with the updated Iris chart and looks good so far, thanks for the jgroup updates!