### PR TITLE
Remove legacy observability interface flag from Dockerfile

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Enforce conventional commit messages
+name: Commit Message Lint
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'lts/*'
+
+      - name: Install commitlint and config
+        run: |
+          npm install --global @commitlint/cli @commitlint/config-conventional
+
+      - name: Lint commits
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+          else
+            npx commitlint --last --verbose
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
 SPDX-License-Identifier: CC0-1.0    
 -->
 
+## [1.1.2]
+### Changed
+- Removed `--legacy-observability-interface` option from the `Dockerfile` to align with updated Keycloak management interface practices. See: https://www.keycloak.org/server/management-interface#_disable_management_interface
+
+---
+
 ## [1.1.1] 
 ### Changed
 - Refactored image build process to use a unified multi-stage `Dockerfile`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,6 @@ RUN /opt/keycloak/bin/kc.sh build \
     --http-relative-path=/auth \
     --metrics-enabled=true \
     --health-enabled=true \
-    --legacy-observability-interface=true \
     --features-disabled=persistent-user-sessions
 
 FROM quay.io/keycloak/keycloak:$BASE_IMAGE_TAG

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ By participating in this project, you agree to abide by its [Code of Conduct](./
 This project follows the [REUSE standard for software licensing](https://reuse.software/).
 Each file contains copyright and license information, and license texts can be found in the [./LICENSES](./LICENSES) folder. For more information visit https://reuse.software/.
 
+## Conventional CommitsAdd commentMore actions
+
+This project enforces [Conventional Commits](https://www.conventionalcommits.org/) for all commits.
+**All commit messages must follow the Conventional Commits specification.**
+This is automatically checked in CI for both pushes and pull requests.
+
 ### REUSE
 
 The [reuse tool](https://github.com/fsfe/reuse-tool) can be used to verify and establish compliance when new files are added. 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,7 @@
+// SPDX-FileCopyrightText: 2025 Deutsche Telekom AG
+// SPDX-License-Identifier: Apache-2.0
+
+// Configuration file for commitlint to enforce Conventional Commits in this repository.
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+};


### PR DESCRIPTION
### 🔧 Summary

Removed the `--legacy-observability-interface=true` flag from the Dockerfile. 

### 🧾 Also included

* Added commit message linting via GitHub Actions

### 🔗 Reference

As per the official Keycloak documentation (https://www.keycloak.org/server/management-interface#_disable_management_interface), the new management endpoints are now the default, and the legacy observability interface should no longer be enabled unless explicitly needed for backward compatibility.
